### PR TITLE
Trocar MySQL por MySQLi

### DIFF
--- a/painel.php
+++ b/painel.php
@@ -4,8 +4,10 @@ $user = "root";
 $pass = "";
 $banco = "cadastro";
 
-$conexao = mysql_connect($host,$user,$pass) or die(mysql_error());
-mysql_select_db($banco) or die(mysql_error());
+$conexao = new mysqli($host, $user, $pass, $banco);
+if($conexao->connect_errno > 0) {
+    die("Erro ao conectar-se no banco de dados!");   // $conexao->connect_error pra debugar
+}
 ?>
 <?php
     session_start();

--- a/userauthentication.php
+++ b/userauthentication.php
@@ -4,8 +4,10 @@ $user = "root";
 $pass = "";
 $banco = "cadastro";
 
-$conexao = mysql_connect($host,$user,$pass) or die(mysql_error());
-mysql_select_db($banco) or die(mysql_error());
+$conexao = new mysqli($host, $user, $pass, $banco);
+if($conexao->connect_errno > 0) {
+    die("Erro ao conectar-se no banco de dados!");   // $conexao->connect_error pra debugar
+}
 ?>
 <html>
     <head>
@@ -26,9 +28,12 @@ mysql_select_db($banco) or die(mysql_error());
 $usuario=$_POST['usuario'];
 $senha=$_POST['senha'];
 
-$sql = mysql_query("SELECT * FROM usuarios WHERE usuario ='$usuario' AND senha='$senha'") or die(mysql_error());
-$row = mysql_num_rows($sql);
-if($row>0){
+$stmt = $conexao->prepare("SELECT * FROM usuarios WHERE usuario = ? AND senha = ?");  // stmt - statement
+$stmt->bind_param('ss',  $usuario, $senha);
+$stmt->execute();
+
+$result = $stmt->get_result();
+if($result->num_rows > 0){
    session_start();
     $_SESSION['usuario'] = $_POST['usuario'];
     $_SESSION['senha'] = $_POST['senha'];


### PR DESCRIPTION
A variável do usuário direto na string sql permitia uma injeção de
código. Mesmo filtrando ela, ainda seria inseguro. Então mudemos de
mysql para mysqli, uma versão melhorada mas que tem o funcionamento
quase igual.

Com mysqli é possível preparar uma declaração (tipo SELECT \* FROM ceu) e depois rodar ela.

http://stackoverflow.com/questions/60174/how-can-i-prevent-sql-injection-in-php
http://php.net/manual/en/mysqli-stmt.bind-param.php
